### PR TITLE
ffmpeg order error and no reencoding options

### DIFF
--- a/bipcut.py
+++ b/bipcut.py
@@ -198,7 +198,7 @@ def ffmpeg_extract_clip(ffmpeg_path, original_file, output_file, start, stop):
 	#ffmpeg -ss 4.63482993197 -to 14.8733106576 -i "D:\\Dropbox\\Caricamenti da fotocamera\\rec.wav" output.mp3
 
 	# Execute ffmpeg to extract the clip
-	p = subprocess.Popen([ffmpeg_path, "-y", "-ss", str(start), "-to", str(stop), "-i", original_file, output_file])
+	p = subprocess.Popen([ffmpeg_path, "-y", "-i", original_file, "-vcodec", "copy", "-acodec", "copy", "-ss", str(start), "-to", str(stop), output_file])
 	return_code = p.wait()
 
 	# Make sure the ffmpeg executed correctly by checking the exit code


### PR DESCRIPTION
I get this error when extracting clips:
```
Option to (record or transcode stop time) cannot be applied to input url VID_20190124_124206.mp4 -- you are trying to apply an input option to an output file or vice versa. Move this option before the file it belongs to.
Error parsing options for input file VID_20190124_124206.mp4.
Error opening input files: Invalid argument
```
Time options need to be after input file.

Also, added `copy` arg to `-vcodec` and `-acodec` to avoid reencoding the extracted clips, which speeds considerably the extraction.